### PR TITLE
Fixes #6 and other misc. stuff

### DIFF
--- a/ClockWork Plugin/pronesupport/plugin/sh_plugin.lua
+++ b/ClockWork Plugin/pronesupport/plugin/sh_plugin.lua
@@ -6,7 +6,7 @@ if SERVER then
 	end
 end
 
-function PLUGIN:PlayerCanRagdoll()
+function PLUGIN:PlayerCanRagdoll(ply)
 	if ply:IsProne() then
 		return false
 	end

--- a/prone_mod/lua/prone/cl_prone.lua
+++ b/prone_mod/lua/prone/cl_prone.lua
@@ -14,6 +14,7 @@ net.Receive("Prone.Entered", function()
 	local ply = net.ReadPlayer()
 
 	if IsValid(ply) then
+		ply.prone = ply.prone or {}
 		ply:AnimRestartMainSequence()
 
 		ply:SetHull(Vector(-16, -16, 0), Vector(16, 16, prone.config.HullHeight))
@@ -32,6 +33,7 @@ net.Receive("Prone.Exit", function()
 	local ply = net.ReadPlayer()
 
 	if IsValid(ply) then
+		ply.prone = ply.prone or {} -- Sometimes the ply.prone table hadn't been initialized for whatever reason, this'll make sure that the IsValid check below doesn't error.
 		ply:AnimRestartMainSequence()
 		ply:ResetHull()	-- For prediction
 
@@ -54,10 +56,15 @@ end)
 -- Other player entities are now valid, lets set up the ones which are prone.
 hook.Add("InitPostEntity", "Prone.PlayerInitialized", function()
 	if prone.IsCompatibility() then
+		for i, v in ipairs(player.GetAll()) do
+			v.prone = v.prone or {} -- Create the prone table for all players... Doesn't really seem to work though
+		end
+
 		net.Start("Prone.PlayerInitialized")
 		net.SendToServer()
 	else
 		for i, v in ipairs(player.GetAll()) do
+			v.prone = v.prone or {} -- Create the prone table for all players... Doesn't really seem to work though
 			if v:IsProne() then
 				v:SetHull(Vector(-16, -16, 0), Vector(16, 16, prone.config.HullHeight))
 				v:SetHullDuck(Vector(-16, -16, 0), Vector(16, 16, prone.config.HullHeight))
@@ -234,6 +241,7 @@ end)
 if prone.IsCompatibility() then
 	-- Creates a fake model and bonemerges it to the player to make it seem alive.
 	function prone.CreateFakeModel(ply, model, clr, bodygrp, plyskin, playercolor)
+		ply.prone = ply.prone or {} -- Sometimes the ply.prone table hadn't been initialized for whatever reason, this'll make sure that the stuff below doesn't error.
 		ply.prone.cl_model = ClientsideModel(model, clr == color_white and RENDERGROUP_OPAQUE or RENDERGROUP_TRANSLUCENT)
 		ply.prone.cl_model.pronemodel = true
 		ply.prone.cl_model:SetOwner(ply)
@@ -255,7 +263,7 @@ if prone.IsCompatibility() then
 	-- Receiver for when we want to update this fake model.
 	net.Receive("Prone.UpdateModel", function()
 		local ply, model = net.ReadPlayer(), net.ReadString()
-		if IsValid(ply) and IsValid(ply.prone.cl_model) then
+		if IsValid(ply) and ply.prone and IsValid(ply.prone.cl_model) then
 			ply.prone.cl_model:SetModel(model)
 		end
 	end)

--- a/prone_mod/lua/prone/sh_prone.lua
+++ b/prone_mod/lua/prone/sh_prone.lua
@@ -2,21 +2,6 @@
 -- Define a bunch of really important meta functions we'll be using
 -------------------------------------------------------------------
 local PLAYER = FindMetaTable("Player")
-PLAYER.prone = {}
-
-if SERVER then
-	if prone.IsCompatibility() then
-		PLAYER.prone.cl_modeldata = {}
-	end
-
-	PLAYER.prone.starttime = 0
-	PLAYER.prone.endtime = 0
-	PLAYER.prone.getuptime = 0
-	PLAYER.prone.getdowntime = 0
-	PLAYER.prone.lastrequest = 0
-	PLAYER.prone.oldviewoffset = Vector(0, 0, 0)
-	PLAYER.prone.oldviewoffset_ducked = Vector(0, 0, 0)
-end
 
 function PLAYER:GetProneAnimationState()
 	return self:GetNWInt("prone.AnimationState", PRONE_NOTINPRONE)
@@ -46,6 +31,25 @@ end
 
 -- Micro-Optimizatios!
 local IsValid, CurTime, type, math_min = IsValid, CurTime, type, math.min
+
+-- Initalise table upon initial spawn
+hook.Add("PlayerInitialSpawn", "Prone.InitialiseTable", function(ply)
+	ply.prone = ply.prone or {}
+
+	if SERVER then
+		if prone.IsCompatibility() then
+			ply.prone.cl_modeldata = {}
+		end
+
+		ply.prone.starttime = 0
+		ply.prone.endtime = 0
+		ply.prone.getuptime = 0
+		ply.prone.getdowntime = 0
+		ply.prone.lastrequest = 0
+		ply.prone.oldviewoffset = Vector(0, 0, 0)
+		ply.prone.oldviewoffset_ducked = Vector(0, 0, 0)
+	end
+end)
 
 ------------------------------------------------------------------
 -- Handles pose parameters and the playback rate of the animations

--- a/prone_mod/lua/prone/sv_prone.lua
+++ b/prone_mod/lua/prone/sv_prone.lua
@@ -190,7 +190,7 @@ end
 -- Makes the player get up and exit prone. Later calls prone.Exit.
 function prone.End(ply)
 	ply.prone.endtime = CurTime()
-	
+
 	-- We do this so then next animation doesn't start mid-way through.
 	ply:AnimRestartMainSequence()
 	net.Start("Prone.ResetMainAnimation")
@@ -276,7 +276,7 @@ end)
 local ipairs, player_GetAll = ipairs, player.GetAll
 timer.Create("Prone.Manage", 1, 0, function()
 	for i, v in ipairs(player_GetAll()) do
-		if v:IsProne() and v:WaterLevel() > 1 and not v:ProneIsGettingUp() then
+		if v:IsProne() and ((v:WaterLevel() > 1 and not v:ProneIsGettingUp()) or v:GetMoveType() == MOVETYPE_NOCLIP) then
 			prone.Exit(v)
 		end
 	end


### PR DESCRIPTION
Exiting prone upon noclip didn't seem to properly work in Clockwork
HL2RP, added noclip check to Prone.Manage to solve it.

Fixes #6 by moving from MetaTable PLAYER.prone to ply.prone, and double
checking that ply.prone exists clientside

Fixes an error caused by the Clockwork plugin when the player is getting
ragdolled due to missing ply as argument