### PR TITLE
Avoid creating PlayerStateData globally

### DIFF
--- a/prone_mod/lua/prone/class_prone_statedata.lua
+++ b/prone_mod/lua/prone/class_prone_statedata.lua
@@ -68,7 +68,7 @@ end
 -- Arg One:		Player entity, whose state data this is.
 -- Returns:		prone.PlayerStateData object.
 function prone.PlayerStateData:New(ply)
-	data = {Player = ply}
+	local data = {Player = ply}
 	setmetatable(data, self)
 	self.__index = self
 	return data

--- a/prone_mod_wos/lua/prone/class_prone_statedata.lua
+++ b/prone_mod_wos/lua/prone/class_prone_statedata.lua
@@ -68,7 +68,7 @@ end
 -- Arg One:		Player entity, whose state data this is.
 -- Returns:		prone.PlayerStateData object.
 function prone.PlayerStateData:New(ply)
-	data = {Player = ply}
+	local data = {Player = ply}
 	setmetatable(data, self)
 	self.__index = self
 	return data


### PR DESCRIPTION
data is created to global table instead of a local instance